### PR TITLE
Changed the glob version to fix the minimatch version fix...

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/thlorenz/viralify",
   "dependencies": {
-    "glob": "~3.2.7",
+    "glob": "^7.1.2",
     "runnel": "~0.5.1",
     "minimist": "0.0.5",
     "ansicolors": "~0.3.2"


### PR DESCRIPTION
npm audit returns this

                       === npm audit security report ===

                                 Manual Review
             Some vulnerabilities require your attention to resolve

          Visit https://go.npm.me/audit-guide for additional guidance

  High            Regular Expression Denial of Service

  Package         minimatch

  Patched in      >=3.0.2

  Dependency of   browserify-swap

  Path            browserify-swap > viralify > glob > minimatch

  More info       https://nodesecurity.io/advisories/118

found 1 high severity vulnerability in 2339 scanned packages
  1 vulnerability requires manual review. See the full report for details.